### PR TITLE
Optionally not resolve relative to namespace

### DIFF
--- a/lib/dry/container/namespace_dsl.rb
+++ b/lib/dry/container/namespace_dsl.rb
@@ -45,8 +45,20 @@ module Dry
         self
       end
 
-      def resolve(key)
-        super(namespaced(key))
+      # Overrides resolve to look into namespace keys first
+      #
+      # @param [Mixed] key
+      #   The key for the item you wish to resolve
+      # @param [Bool] namespaced
+      #   Indicates whether or not the key will be namespaced, defaults to true
+      #
+      # @return [Mixed]
+      #
+      # @api public
+      def resolve(key, namespaced: true)
+        key = namespaced(key) if namespaced
+
+        super(key)
       end
 
       private

--- a/spec/support/shared_examples/container.rb
+++ b/spec/support/shared_examples/container.rb
@@ -472,6 +472,24 @@ RSpec.shared_examples 'a container' do
           is_expected.to eq(2)
         end
       end
+
+      context 'with nesting and when block takes non namespaced argument' do
+        before do
+          container.namespace('one') do |c|
+            c.register('two', 2)
+          end
+
+          container.namespace('three') do |c|
+            c.register('four', c.resolve('one.two', namespaced: false))
+          end
+        end
+
+        subject! { container.resolve('three.four') }
+
+        it 'resolves items relative to the namespace' do
+          is_expected.to eq(2)
+        end
+      end
     end
 
     describe 'import' do


### PR DESCRIPTION
PR #47 introduced feature to resolve relative to the namespace but there
wasn't an option to resolve keys from other namespaces or the root.
This changes gives people the option to disable the relative
namespacing